### PR TITLE
Add touch support and add image fade-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - allow panning on mobile using touch
 
+### Fixed
+- image's alt text was showing up before image was loaded. Changed default opacity to 0.
+
 ## [1.0.0] - 2018-08-28
 ### Added
 - Babel plugin `babel-plugin-react-css-modules` to automatically convert `styleName` to `className` using the correct css module, in both webpack and rollup builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- allow panning on mobile using touch
 
 ## [1.0.0] - 2018-08-28
 ### Added

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -49,6 +49,9 @@ class ImageCloseup extends Component {
     this.onDrag = this.onDrag.bind(this);
     this.onDragStart = this.onDragStart.bind(this);
     this.onDragEnd = this.onDragEnd.bind(this);
+    this.onTouchStart = this.onTouchStart.bind(this);
+    this.onTouchMove = this.onTouchMove.bind(this);
+    this.onTouchEnd = this.onTouchEnd.bind(this);
     this.handleImageLoad = this.handleImageLoad.bind(this);
     this.zoomIn = this.zoomIn.bind(this);
     this.zoomOut = this.zoomOut.bind(this);
@@ -61,13 +64,6 @@ class ImageCloseup extends Component {
     // prevent dragging behaviour
     window.ondragstart = () => false;
     window.addEventListener('resize', this.onResizeWindow);
-    // Inject css
-    // if (!document.querySelector('style#react-image-closeup')) {
-    //   const tag = document.createElement('style');
-    //   tag.id = 'react-image-closeup';
-    //   tag.innerHTML = cssStyles;
-    //   document.getElementsByTagName('head')[0].appendChild(tag);
-    // }
   }
 
   componentWillUnmount() {
@@ -108,6 +104,18 @@ class ImageCloseup extends Component {
       translateX: positionWithinRange(translateX, width, stageWidth),
       translateY: positionWithinRange(translateY, height, stageHeight),
     });
+  }
+
+  onTouchStart(e) {
+    this.onDragStart(e.changedTouches[0]);
+  }
+
+  onTouchMove(e) {
+    this.onDrag(e.changedTouches[0]);
+  }
+
+  onTouchEnd(e) {
+    this.onDragEnd(e.changedTouches[0]);
   }
 
   onResizeWindow() {
@@ -188,6 +196,9 @@ class ImageCloseup extends Component {
           onMouseDown={this.onDragStart}
           onMouseUp={this.onDragEnd}
           onMouseLeave={this.onDragEnd}
+          onTouchStart={this.onTouchStart}
+          onTouchMove={this.onTouchMove}
+          onTouchEnd={this.onTouchEnd}
           ref={(elem) => { this.container = elem; }}
           style={{
             ...styles.imageContainer,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -27,6 +27,11 @@ const styles = {
     maxHeight: '100vh',
     maxWidth: '100vw',
     userSelect: 'none',
+    transition: 'opacity 1s',
+    opacity: 0,
+  },
+  loaded: {
+    opacity: 1,
   },
 };
 
@@ -212,7 +217,10 @@ class ImageCloseup extends Component {
             onLoad={this.handleImageLoad}
             alt={this.props.imageAltText}
             ref={(elem) => { this.image = elem; }}
-            style={styles.img}
+            style={{
+              ...styles.img,
+              ...(this.state.imageLoaded ? styles.loaded : {}),
+            }}
           />
         </div>
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,2 +1,0 @@
-@import 'loader.css';
-@import 'actionIcons.css';


### PR DESCRIPTION
Add's touch support for mobile so the image can be panned when zoomed in. Also added a fade-in transition to the image once it loaded (prior to this, the alt text and broken image icon was displaying behind the loader animation)