### PR TITLE
Add standalone component example into the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added an example of how to load the react-image-closeup component as a script from CDN and a CodePen link with a demo
 
 ## [1.0.0] - 2018-08-28
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,9 +13,26 @@ Here is a [Demo](https://grittly.github.io/react-image-closeup/) of the componen
 ## Installation
 
 **npm**
+
 ```
 npm install react-image-closeup --save
 ```
+
+**standalone**
+
+You can load the standalone version of the component from `node_modules/standalone/react_image_closeup.production.min.js` or via CDN `https://unpkg.com/react-image-closeup`. The package requires `react`, `react-dom` and `prop-types`.
+
+```html
+<script src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
+<script src="https://unpkg.com/prop-types@15.6/prop-types.min.js"></script>
+<script src="https://unpkg.com/react-image-closeup"></script>
+<script>
+  // Your code here
+</script>
+```
+
+To see a full example, check out this [CodePen](https://codepen.io/grittly/pen/aaWqQY)
 
 ## Usage
 ```javascript


### PR DESCRIPTION
Added an example of how to load the react-image-closeup component as a script from CDN and a CodePen link with a demo